### PR TITLE
Allow volumes with hyphens in the name

### DIFF
--- a/director.go
+++ b/director.go
@@ -143,7 +143,7 @@ func (r *rulesDirector) Direct(l socketproxy.Logger, req *http.Request, upstream
 		return r.addLabelsToBody(l, req, upstream)
 	case match(`POST`, `^/volumes/prune$`):
 		return r.addLabelsToQueryStringFilters(l, req, upstream)
-	case match(`GET`, `^/volumes/(\w+)$`), match(`DELETE`, `^/volumes/(\w+)$`):
+	case match(`GET`, `^/volumes/([-\w]+)$`), match(`DELETE`, `^/volumes/(-\w+)$`):
 		if ok, err := r.checkOwner(l, "volumes", true, req); ok {
 			return upstream
 		} else if err == errInspectNotFound {
@@ -162,7 +162,7 @@ func (r *rulesDirector) Direct(l socketproxy.Logger, req *http.Request, upstream
 var identifierPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`^/containers/(.+?)(?:/\w+)?$`),
 	regexp.MustCompile(`^/networks/(.+?)(?:/\w+)?$`),
-	regexp.MustCompile(`^/volumes/(\w+?)(?:/\w+)?$`),
+	regexp.MustCompile(`^/volumes/([-\w]+?)(?:/\w+)?$`),
 	regexp.MustCompile(`^/images/(.+?)/(?:json|history|push|tag)$`),
 	regexp.MustCompile(`^/images/([^/]+)$`),
 	regexp.MustCompile(`^/images/(\w+/[^/]+)$`),

--- a/director_test.go
+++ b/director_test.go
@@ -957,6 +957,9 @@ func TestCheckOwner(t *testing.T) {
 			"namewithlabel1": upstreamStateVolume{
 				owner: "test-owner",
 			},
+			"name-with-label2": upstreamStateVolume{
+				owner: "test-owner",
+			},
 		},
 	}
 
@@ -980,6 +983,8 @@ func TestCheckOwner(t *testing.T) {
 		"/v1.37/networks/idwithnolabel": {"networks", false},
 		// A volume that will match
 		"/v1.37/volumes/namewithlabel1": {"volumes", true},
+		// A volume that will match
+		"/v1.37/volumes/name-with-label2": {"volumes", true},
 		// A volume that won't match
 		"/v1.37/volumes/namewithnolabel": {"volumes", false},
 	}


### PR DESCRIPTION
Prior to this patch, sockguard would return something like:

```
GET /v1.30/volumes/ecs-jenkins-...-bccfa78debe6e3b4a901 not implemented yet
```